### PR TITLE
test: add Feature tests for authentication and authorization

### DIFF
--- a/database/factories/CalendarFactory.php
+++ b/database/factories/CalendarFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Calendar>
+ */
+class CalendarFactory extends Factory
+{
+    public function definition()
+    {
+        return [
+            'user_id' => User::factory(),
+            'date' => fake()->date(),
+            'title' => fake()->sentence(3),
+            'description' => fake()->paragraph(),
+        ];
+    }
+}

--- a/tests/Feature/CalendarAuthorizationTest.php
+++ b/tests/Feature/CalendarAuthorizationTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Calendar;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CalendarAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_edit_own_calendar_entry()
+    {
+        $user = User::factory()->create();
+        $entry = Calendar::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->get(route('calendar.edit', $entry->id));
+
+        $response->assertStatus(200);
+    }
+
+    public function test_user_cannot_edit_another_users_calendar_entry()
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $entry = Calendar::factory()->create(['user_id' => $owner->id]);
+
+        $response = $this->actingAs($other)->get(route('calendar.edit', $entry->id));
+
+        $response->assertStatus(403);
+    }
+
+    public function test_user_can_delete_own_calendar_entry()
+    {
+        $user = User::factory()->create();
+        $entry = Calendar::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->delete(route('calendar.destroy', $entry->id));
+
+        $response->assertRedirect(route('calendar.index'));
+        $this->assertDatabaseMissing('calendars', ['id' => $entry->id]);
+    }
+
+    public function test_user_cannot_delete_another_users_calendar_entry()
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $entry = Calendar::factory()->create(['user_id' => $owner->id]);
+
+        $response = $this->actingAs($other)->delete(route('calendar.destroy', $entry->id));
+
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('calendars', ['id' => $entry->id]);
+    }
+
+    public function test_user_cannot_update_another_users_calendar_entry()
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $entry = Calendar::factory()->create(['user_id' => $owner->id]);
+
+        $response = $this->actingAs($other)->put(route('calendar.update', $entry->id), [
+            'date' => '2026-05-01',
+            'title' => 'Hacked',
+            'description' => 'Unauthorized update',
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_user_cannot_view_another_users_calendar_entry()
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $entry = Calendar::factory()->create(['user_id' => $owner->id]);
+
+        $response = $this->actingAs($other)->get(route('calendar.show', $entry->id));
+
+        $response->assertStatus(403);
+    }
+
+    public function test_guest_is_redirected_to_login_for_protected_routes()
+    {
+        $entry = Calendar::factory()->create();
+
+        $this->get(route('calendar.index'))->assertRedirect(route('login'));
+        $this->get(route('calendar.create'))->assertRedirect(route('login'));
+        $this->get(route('calendar.show', $entry->id))->assertRedirect(route('login'));
+        $this->get(route('calendar.edit', $entry->id))->assertRedirect(route('login'));
+        $this->delete(route('calendar.destroy', $entry->id))->assertRedirect(route('login'));
+    }
+}

--- a/tests/Feature/CalendarTest.php
+++ b/tests/Feature/CalendarTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Calendar;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CalendarTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_user_can_view_calendar_index()
+    {
+        $user = User::factory()->create();
+        Calendar::factory()->count(3)->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->get(route('calendar.index'));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('calendar.index');
+        $response->assertViewHas('schedules');
+    }
+
+    public function test_authenticated_user_can_view_create_form()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('calendar.create'));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('calendar.create');
+    }
+
+    public function test_authenticated_user_can_create_a_calendar_entry()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('calendar.store'), [
+            'date' => '2026-04-15',
+            'title' => 'Team Meeting',
+            'description' => 'Weekly sync meeting',
+        ]);
+
+        $response->assertRedirect(route('calendar.index'));
+        $this->assertDatabaseHas('calendars', [
+            'user_id' => $user->id,
+            'description' => 'Weekly sync meeting',
+        ]);
+    }
+
+    public function test_authenticated_user_can_view_own_calendar_entry()
+    {
+        $user = User::factory()->create();
+        $entry = Calendar::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->get(route('calendar.show', $entry->id));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('calendar.show');
+        $response->assertViewHas('schedule');
+    }
+
+    public function test_authenticated_user_can_update_own_calendar_entry()
+    {
+        $user = User::factory()->create();
+        $entry = Calendar::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->put(route('calendar.update', $entry->id), [
+            'date' => '2026-05-01',
+            'title' => 'Updated Title',
+            'description' => 'Updated description',
+        ]);
+
+        $response->assertRedirect(route('calendar.index'));
+        $this->assertDatabaseHas('calendars', [
+            'id' => $entry->id,
+            'title' => 'Updated Title',
+            'description' => 'Updated description',
+        ]);
+    }
+
+    public function test_authenticated_user_can_delete_own_calendar_entry()
+    {
+        $user = User::factory()->create();
+        $entry = Calendar::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->delete(route('calendar.destroy', $entry->id));
+
+        $response->assertRedirect(route('calendar.index'));
+        $this->assertDatabaseMissing('calendars', ['id' => $entry->id]);
+    }
+
+    public function test_unauthenticated_user_is_redirected_to_login()
+    {
+        $entry = Calendar::factory()->create();
+
+        $this->get(route('calendar.index'))->assertRedirect(route('login'));
+        $this->post(route('calendar.store'), [])->assertRedirect(route('login'));
+        $this->get(route('calendar.show', $entry->id))->assertRedirect(route('login'));
+        $this->put(route('calendar.update', $entry->id), [])->assertRedirect(route('login'));
+        $this->delete(route('calendar.destroy', $entry->id))->assertRedirect(route('login'));
+    }
+
+    public function test_store_validation_errors_for_missing_fields()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('calendar.store'), []);
+
+        $response->assertRedirect(route('calendar.create'));
+        $response->assertSessionHasErrors(['date', 'description']);
+    }
+
+    public function test_update_validation_errors_for_missing_fields()
+    {
+        $user = User::factory()->create();
+        $entry = Calendar::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->put(route('calendar.update', $entry->id), []);
+
+        $response->assertRedirect(route('calendar.edit', $entry->id));
+        $response->assertSessionHasErrors(['date', 'title', 'description']);
+    }
+
+    public function test_authenticated_user_can_view_mypage()
+    {
+        $user = User::factory()->create();
+        $ownEntry = Calendar::factory()->create(['user_id' => $user->id]);
+        $otherEntry = Calendar::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('calendar.mypage'));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('calendar.index');
+        $response->assertViewHas('schedules');
+    }
+}


### PR DESCRIPTION
Closes #14

## Changes
- Add `CalendarFactory` for generating test calendar entries
- Add `CalendarAuthorizationTest` with 7 test cases covering:
  - Owner can edit their own calendar entry (200)
  - Owner can delete their own calendar entry (redirect + DB verification)
  - Non-owner receives 403 on edit, update, delete, and view attempts
  - Guest users are redirected to login for all protected routes
- Uses `RefreshDatabase` trait and two separate user factories for cross-user access testing

## Test plan
- [ ] Run `php artisan test --filter=CalendarAuthorizationTest` and verify all 7 tests pass
- [ ] Verify no existing tests are broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)